### PR TITLE
WIP: Links to sub components

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -24,7 +24,7 @@ class App extends Component {
     const { isMenuOpen } = this.state;
 
     return (
-      <Router history={history}>
+      <Router history={history} autoScrollToHash={false}>
         <Fragment>
           <Header onToggleMenu={this.onToggleMenu} />
           <div className="app_body">

--- a/docs/src/vendor/doc-components/markdown/anchor-heading.js
+++ b/docs/src/vendor/doc-components/markdown/anchor-heading.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import _ from 'lodash';
+
+export default class AnchorHeading extends Component {
+  render() {
+    const { children, level } = this.props;
+
+    const tagname = `h${level}`;
+
+    const value = _.get(children, '0', '');
+    const isText = typeof value === 'string';
+
+    let id;
+    if (isText) {
+      id = _.kebabCase(value);
+    } else {
+      id = _
+        .chain(value)
+        .get('props.value', '')
+        .kebabCase()
+        .value();
+    }
+
+    return React.createElement(tagname, { id }, children);
+  }
+}

--- a/docs/src/vendor/doc-components/markdown/markdown.js
+++ b/docs/src/vendor/doc-components/markdown/markdown.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { fetchDedupe } from 'fetch-dedupe';
 import CodeHighlighter from './code-highlighter';
+import AnchorHeading from './anchor-heading';
 
 export default class Markdown extends Component {
   render() {
@@ -16,6 +17,7 @@ export default class Markdown extends Component {
         source={markdownText}
         className={`markdown ${this.props.className}`}
         renderers={{
+          heading: AnchorHeading,
           code: CodeHighlighter,
         }}
       />


### PR DESCRIPTION
Will resolve #149 

---

Right now, the hash tags are linking too high on the page. I think this is due to the dynamic content rendering above it, which increases the height of the page once it loads. It is probably the component example and the associated code loading a fraction of a second after the rest of the page.