### PR TITLE
Add nodeRef props to remaining components

### DIFF
--- a/docs/readmes/input.md
+++ b/docs/readmes/input.md
@@ -11,10 +11,10 @@ import 'materialish/materialish.css';
 | --------- | ------------- | ------------------------------------------------------------------------------------------------- |
 | className |               | Additional class name(s) to add to the input                                                      |
 | error     | false         | Whether or not the input is in an invalid state                                                   |
-| nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the `input` element |
 | clearable | false         | Pass `true` to display a button to clear the input when there is text                             |
 | onClear   |               | A function that is called when the user clicks the clear button (see the `clearable` prop)        |
 | icon      |               | An optional [Icon](/icons) to display on the left side of the input                               |
+| nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the `input` element |
 | ...rest   |               | Other props are placed on the root `input` element                                                |
 
 ## CSS Variables

--- a/docs/readmes/navigation.md
+++ b/docs/readmes/navigation.md
@@ -9,15 +9,16 @@ import 'materialish/materialish.css';
 
 ## Props
 
-| Prop Name | Default Value | Description                                                                       |
-| --------- | ------------- | --------------------------------------------------------------------------------- |
-| className |               | Additional class name(s) to add to the navigation                                 |
-| children  |               | One or more `Navigation.Item` components                                          |
-| vertical  | false         | Whether to render the navigation vertically or horizontally                       |
-| centered  | false         | Pass `true` to center the `Navigation.Item`s within the navigation                |
-| fullWidth | false         | Pass `true` for the `Navigation.Item`s to span the entire width of the navigation |
-| ripple    | true          | Pass `false` to disable the ripple effect on the Navigation                       |
-| ...rest   |               | Other props are placed on the root node of the navigation                         |
+| Prop Name | Default Value | Description                                                                                 |
+| --------- | ------------- | ------------------------------------------------------------------------------------------- |
+| className |               | Additional class name(s) to add to the navigation                                           |
+| children  |               | One or more `Navigation.Item` components                                                    |
+| vertical  | false         | Whether to render the navigation vertically or horizontally                                 |
+| centered  | false         | Pass `true` to center the `Navigation.Item`s within the navigation                          |
+| fullWidth | false         | Pass `true` for the `Navigation.Item`s to span the entire width of the navigation           |
+| ripple    | true          | Pass `false` to disable the ripple effect on the Navigation                                 |
+| nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the root node |
+| ...rest   |               | Other props are placed on the root node of the navigation                                   |
 
 ## CSS Variables
 
@@ -31,10 +32,11 @@ import 'materialish/materialish.css';
 
 ## Props
 
-| Prop Name | Default Value | Description                                                                               |
-| --------- | ------------- | ----------------------------------------------------------------------------------------- |
-| className |               | Additional class name(s) to add to the navigation item                                    |
-| children  |               | The contents to render within the navigation item                                         |
-| active    | false         | Pass `true` for this item to be active. Only one item should be active at a time.         |
-| ripple    |               | Use this prop to override the Navigation's `ripple` prop on a per-`Navigation.Item` basis |
-| ...rest   |               | Other props are placed on the root element of the navigation item                         |
+| Prop Name | Default Value | Description                                                                                 |
+| --------- | ------------- | ------------------------------------------------------------------------------------------- |
+| className |               | Additional class name(s) to add to the navigation item                                      |
+| children  |               | The contents to render within the navigation item                                           |
+| active    | false         | Pass `true` for this item to be active. Only one item should be active at a time.           |
+| ripple    |               | Use this prop to override the Navigation's `ripple` prop on a per-`Navigation.Item` basis   |
+| nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the root node |
+| ...rest   |               | Other props are placed on the root element of the navigation item                           |

--- a/docs/readmes/table.md
+++ b/docs/readmes/table.md
@@ -100,9 +100,10 @@ Expanded row content should be used as a sibling of a Table Cell.
 
 ## Props
 
-| Prop Name | Default Value | Description                                                                 |
-| --------- | ------------- | --------------------------------------------------------------------------- |
-| className |               | Additional class name(s) to add to the expanded row content                 |
-| children  |               | An array of `Table.Cell` elements to render within the expanded row content |
-| open      | false         | Whether or not to display the expanded content                              |
-| ...rest   |               | Other props are placed on the root element of the expanded row content      |
+| Prop Name | Default Value | Description                                                                                 |
+| --------- | ------------- | ------------------------------------------------------------------------------------------- |
+| className |               | Additional class name(s) to add to the expanded row content                                 |
+| children  |               | An array of `Table.Cell` elements to render within the expanded row content                 |
+| open      | false         | Whether or not to display the expanded content                                              |
+| nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the root node |
+| ...rest   |               | Other props are placed on the root element of the expanded row content                      |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "materialish",
-  "version": "0.17.0-beta.2",
+  "version": "0.17.0-beta.3",
   "description": "React components that loosely follow Material Design",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import IconClose from '../icons/icon-close';
+import warning from '../utils/warning';
 
 export default class Input extends Component {
   render() {
@@ -69,7 +70,7 @@ export default class Input extends Component {
                 }
               }
             }}
-            onClick={(e) => {
+            onClick={e => {
               if (this.nodeRef && this.nodeRef.focus) {
                 this.nodeRef.focus();
               }
@@ -87,14 +88,23 @@ export default class Input extends Component {
   getRef = ref => {
     const { nodeRef } = this.props;
 
-    if (typeof nodeRef === 'function') {
+    this.nodeRef = ref;
+
+    if (typeof nodeRef === 'string') {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(
+          `You passed a string ref as an Input component's nodeRef prop. ` +
+            `String refs are not supported in Materialish components. You may only pass a ` +
+            `callback ref or the value returned by createRef(). Your ref has been ignored.`,
+          'INVALID_NODE_REF_PROP'
+        );
+      }
+    } else if (typeof nodeRef === 'function') {
       nodeRef(ref);
     } else if (nodeRef && nodeRef.hasOwnProperty('current')) {
       nodeRef.current = ref;
     }
-
-    this.nodeRef = ref;
-  }
+  };
 }
 
 Input.propTypes = {

--- a/src/navigation/navigation.js
+++ b/src/navigation/navigation.js
@@ -1,6 +1,7 @@
 import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Ripple from '../ripple/ripple';
+import warning from '../utils/warning';
 
 const NavigationContext = React.createContext();
 
@@ -13,6 +14,7 @@ export default class Navigation extends Component {
       fullWidth = false,
       vertical = false,
       ripple,
+      nodeRef, // Unused; this is to remove it from `...props`
       ...props
     } = this.props;
 
@@ -82,8 +84,25 @@ export default class Navigation extends Component {
     });
   };
 
-  getRef = el => {
-    this.el = el;
+  getRef = ref => {
+    const { nodeRef } = this.props;
+
+    this.el = ref;
+
+    if (typeof nodeRef === 'string') {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(
+          `You passed a string ref as an Input component's nodeRef prop. ` +
+            `String refs are not supported in Materialish components. You may only pass a ` +
+            `callback ref or the value returned by createRef(). Your ref has been ignored.`,
+          'INVALID_NODE_REF_PROP'
+        );
+      }
+    } else if (typeof nodeRef === 'function') {
+      nodeRef(ref);
+    } else if (nodeRef && nodeRef.hasOwnProperty('current')) {
+      nodeRef.current = ref;
+    }
   };
 
   updateTrackerPosition = () => {
@@ -168,11 +187,13 @@ class Item extends Component {
       ripple = true,
       updateTrackerPosition,
       active,
+      nodeRef,
       ...props
     } = this.props;
 
     return (
       <button
+        ref={nodeRef}
         className={`mt-navigation_item ${
           active ? 'mt-navigation_item-active' : ''
         } ${className}`}

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import warning from '../utils/warning';
 
 const TableContext = React.createContext({ columnProps: {} });
 
@@ -276,7 +277,7 @@ TableCell.propTypes = {
 
 class TableExpandedRowContent extends Component {
   render() {
-    const { className = '', children, open, ...props } = this.props;
+    const { className = '', children, open, nodeRef, ...props } = this.props;
 
     return (
       <div
@@ -313,8 +314,25 @@ class TableExpandedRowContent extends Component {
     }
   }
 
-  getRef = el => {
-    this.el = el;
+  getRef = ref => {
+    const { nodeRef } = this.props;
+
+    this.el = ref;
+
+    if (typeof nodeRef === 'string') {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(
+          `You passed a string ref as an Input component's nodeRef prop. ` +
+            `String refs are not supported in Materialish components. You may only pass a ` +
+            `callback ref or the value returned by createRef(). Your ref has been ignored.`,
+          'INVALID_NODE_REF_PROP'
+        );
+      }
+    } else if (typeof nodeRef === 'function') {
+      nodeRef(ref);
+    } else if (nodeRef && nodeRef.hasOwnProperty('current')) {
+      nodeRef.current = ref;
+    }
   };
 }
 

--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -1,0 +1,27 @@
+/* eslint no-console:off */
+
+let codeCache = {};
+
+export default function warning(message, code) {
+  // This ensures that each warning type is only logged out one time
+  if (code) {
+    if (codeCache[code]) {
+      return;
+    }
+
+    codeCache[code] = true;
+  }
+
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error(message);
+  }
+
+  try {
+    // This error was thrown as a convenience so that if you enable
+    // "break on all exceptions" in your console,
+    // it would pause the execution at this line.
+    throw new Error(message);
+  } catch (e) {
+    // Intentionally blank
+  }
+}


### PR DESCRIPTION
This adds `nodeRef` to the remaining components.

Resolves #275 

> Note: `Menu` still does not have `nodeRef` props. This is due to upcoming planned refactors (#247 and possibly others).