### PR TITLE
add Materialish typings (just for Button)

### DIFF
--- a/build/copy-source-files.js
+++ b/build/copy-source-files.js
@@ -4,9 +4,11 @@ const path = require('path');
 const glob = require('glob');
 const chalk = require('chalk');
 const copyFiles = require('./copy-files');
+const renameFile = require('./rename-file');
 
 const COMPONENT_DIR = path.join(__dirname, '..', 'src');
 const DESTINATION_DIRECTORY = path.join(__dirname, '..');
+const DIST_DIRECTORY = path.join(__dirname, '../dist');
 
 const cssFilesToCopy = `${COMPONENT_DIR}/*/*.css`;
 
@@ -18,3 +20,7 @@ glob(cssFilesToCopy, function(err, files) {
 
   copyFiles(files, DESTINATION_DIRECTORY);
 });
+
+// Copy the TS typings to dist.
+copyFiles([`${COMPONENT_DIR}/index.d.ts`], DIST_DIRECTORY);
+renameFile(`${DIST_DIRECTORY}/index.d.ts`, `${DIST_DIRECTORY}/materialish.d.ts`)

--- a/build/rename-file.js
+++ b/build/rename-file.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const fs = require('fs');
+const chalk = require('chalk');
+
+module.exports = function (oldFileName, newFileName, onStartMsg, onEndMsg) {
+  const startMsg = onStartMsg || `Renaming ${oldFileName} to ${newFileName}`;
+  const endMsg = onEndMsg || '✔ The file was successfully renamed!';
+  console.log(chalk.blue(startMsg));
+
+  fs.renameSync(oldFileName, newFileName);
+
+  console.log(chalk.green(endMsg));
+};

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "*.css",
     "icons-data.json"
   ],
+  "types": "dist/materialish.d.ts",
   "homepage": "https://materialish.js.org",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+
+function refFn<T>(): React.RefObject<T>;
+
+export type ButtonProps = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+  nodeRef?: refFn<HTMLButtonElement>;
+  flat?: boolean;
+  ripple?: boolean;
+  raised?: boolean;
+  stroked?: boolean;
+  compact?: boolean;
+};
+
+export class Button extends React.Component<ButtonProps> { }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Materialish typings.
+ * TODO: TS does not yet support bundling *.d.ts files, so for now all definitions will live here:
+ * https://github.com/Microsoft/TypeScript/issues/4433
+ */
+
 import React from 'react';
 
 function refFn<T>(): React.RefObject<T>;


### PR DESCRIPTION
this PR adds a typings file that can be used for adding typings definitions for all exported materialish functions / classes.

Though it is possible to break up typings files by component (e.g. into button/button.d.ts), and then merge them using a tool like dts-generator -- we've received caution that that tool can be buggy.

Official support for bundling typings files should arrive soon, at which breaking apart the files will be possible:

https://github.com/Microsoft/TypeScript/issues/4433