### PR TITLE
A11y: add aria to Avatar

### DIFF
--- a/docs/readmes/avatar.md
+++ b/docs/readmes/avatar.md
@@ -12,6 +12,7 @@ import 'materialish/materialish.css';
 | className |               | Additional class name(s) to add to the Avatar                                               |
 | image     |               | The URL for the user's picture                                                              |
 | initials  |               | The user's initials                                                                         |
+| alt  |                    | The user's name                                                                         |
 | nodeRef   |               | Pass a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to get access to the root node |
 | ...rest   |               | Other props are placed on the root element of the Avatar                                    |
 

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -7,6 +7,7 @@ class Avatar extends Component {
       className = '',
       image,
       initials = '',
+      alt = '',
       style,
       nodeRef,
       ...props
@@ -20,6 +21,8 @@ class Avatar extends Component {
           '--mt-avatar-bg-image': `url('${image}')`,
           ...style,
         }}
+        role="img"
+        aria-label={alt}
         {...props}>
         {!image && <div className="mt-avatar_initials">{initials}</div>}
       </div>

--- a/stories/avatar.stories.js
+++ b/stories/avatar.stories.js
@@ -14,6 +14,7 @@ storiesOf('Avatar', module)
   .add('Regular', () => (
     <Avatar
       image="https://randomuser.me/api/portraits/women/50.jpg"
+      alt="Jayden Peyton"
       onClick={action('clicked')}
     />
   ))


### PR DESCRIPTION
this change for A11y and this is a workaround to get the same result for `<img src="" alt=""/>`  #232 .
- Add `role="img"` to indicate this is image for Screen readers.
- Add `aria-label={alt}` to add name for image.
- Add prop called `alt`.
