### PR TITLE
A11y: hide svg icons from SR

### DIFF
--- a/build/generate-icons.js
+++ b/build/generate-icons.js
@@ -135,7 +135,7 @@ clone(
         iconData.icons.push(iconInformation);
 
         let svg = contents
-          .replace('>', ' {...rest} > ')
+          .replace('>', ' aria-hidden="true" focusable="false" {...rest} > ')
           .replace(/width="48"/, '')
           .replace(/height="48"/, 'style={styleToApply}');
 

--- a/docs/examples/icon-button.js
+++ b/docs/examples/icon-button.js
@@ -1,7 +1,7 @@
 class IconButtonsExample extends Component {
   render() {
     return (
-      <IconButton>
+      <IconButton aria-label="Alarm">
         <IconAlarmOn />
       </IconButton>
     );

--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -13,7 +13,7 @@ class Ripple extends Component {
       '--mt-ripple-left': left,
     };
 
-    return <span style={styles} className={classname} onClick={this.onClick} />;
+    return <span style={styles} className={classname} onClick={this.onClick} aria-hidden="true"/>;
   }
 
   state = {


### PR DESCRIPTION
- Add `aria-label` to an icon-button example.
- Add `aria-hidden` and `focusable` to SVG icons to hide it from Screen readers and focusable to false to prevent IE11 getting focus in the SVG icon.
- Add `aria-hidden` to ripple because it's decorative element.